### PR TITLE
Add ability to limit bandwidth of simulcast tracks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export {
-  BandwidthLimit,
+  TrackBandwidthLimit,
   Callbacks,
   MembraneWebRTCConfig,
   MembraneWebRTC,

--- a/src/membraneWebRTC.ts
+++ b/src/membraneWebRTC.ts
@@ -576,12 +576,13 @@ export class MembraneWebRTC {
   }
   
   private applyBitrateLimitation(encodings: RTCRtpEncodingParameters[], max_bitrate: TrackBandwidthLimit) {
-    if(max_bitrate instanceof Number) {
+    if(typeof max_bitrate === "number") {
       // non-simulcast limitation
       this.splitBitrate(encodings, (max_bitrate as number) * 1024)
     } else {
       // simulcast bandwidth limit
       encodings.filter(encoding => encoding.rid).forEach(encoding => {
+        console.log(max_bitrate);
         const limit = (max_bitrate as SimulcastBandwidthLimit).get(encoding.rid!) || 0
 
         if(limit > 0)
@@ -730,6 +731,11 @@ export class MembraneWebRTC {
    */
   public setLayerBandwidth(trackId: string, layer: string, bandwidth: BandwidthLimit): Promise<boolean> {
     const trackContext = this.localTrackIdToTrack.get(trackId)!;
+
+    if(!trackContext) {
+      return Promise.reject(`Track '${trackId}' doesn't exist`)
+    }
+
     const sender = this.findSender(trackContext.track!!.id);
     const parameters = sender.getParameters();
     const encoding = parameters.encodings.find(encoding => encoding.rid === layer)

--- a/src/membraneWebRTC.ts
+++ b/src/membraneWebRTC.ts
@@ -30,9 +30,7 @@ export interface Peer {
 
 
 /**
- * Type describing track's Bandwidth limit in kbps. 0 is interpreted as unlimited bandwidth.
- * 
- * This type also describes bandwidth limit for non-simulcast tracks or overall bandwidth limitation for simulcast tracks.
+ * Type describing maximal bandwidth that can be used, in kbps. 0 is interpreted as unlimited bandwidth.
  */
 export type BandwidthLimit = number;
 

--- a/src/membraneWebRTC.ts
+++ b/src/membraneWebRTC.ts
@@ -32,13 +32,14 @@ export interface Peer {
 /**
  * Type describing track's Bandwidth limit in kbps. 0 is interpreted as unlimited bandwidth.
  * 
- * This type also describes bandwidth limit for non-simulcast tracks
+ * This type also describes bandwidth limit for non-simulcast tracks or overall bandwidth limitation for simulcast tracks.
  */
 export type BandwidthLimit = number;
 
 /**
  * Type describing bandwidth limit for simulcast track.
- * It is a mapping (layer => BandwidthLimit)
+ * It is a mapping (encoding => BandwidthLimit).
+ * If encoding isn't present in this mapping, it will be assumed that this particular encoding shouldn't have any bandwidth limit 
  */
 export type SimulcastBandwidthLimit = Map<string, BandwidthLimit>;
 
@@ -570,20 +571,19 @@ export class MembraneWebRTC {
     }
     
     if(trackContext.maxBandwidth && transceiverConfig.sendEncodings && trackContext.maxBandwidth > 0)
-      this.applyBitrateLimitation(transceiverConfig.sendEncodings, trackContext.maxBandwidth);
+      this.applyBandwidthLimitation(transceiverConfig.sendEncodings, trackContext.maxBandwidth);
 
     return transceiverConfig;
   }
   
-  private applyBitrateLimitation(encodings: RTCRtpEncodingParameters[], max_bitrate: TrackBandwidthLimit) {
-    if(typeof max_bitrate === "number") {
+  private applyBandwidthLimitation(encodings: RTCRtpEncodingParameters[], max_bandwidth: TrackBandwidthLimit) {
+    if(typeof max_bandwidth === "number") {
       // non-simulcast limitation
-      this.splitBitrate(encodings, (max_bitrate as number) * 1024)
+      this.splitBandwidth(encodings, (max_bandwidth as number) * 1024)
     } else {
       // simulcast bandwidth limit
       encodings.filter(encoding => encoding.rid).forEach(encoding => {
-        console.log(max_bitrate);
-        const limit = (max_bitrate as SimulcastBandwidthLimit).get(encoding.rid!) || 0
+        const limit = (max_bandwidth as SimulcastBandwidthLimit).get(encoding.rid!) || 0
 
         if(limit > 0)
           encoding.maxBitrate = limit * 1024
@@ -593,7 +593,12 @@ export class MembraneWebRTC {
     }
   }
   
-  private splitBitrate(encodings: RTCRtpEncodingParameters[], bitrate: number) {
+  private splitBandwidth(encodings: RTCRtpEncodingParameters[], bandwidth: number) {
+    if(bandwidth === 0) {
+      encodings.forEach(encoding => delete encoding.maxBitrate) 
+      return;
+    }
+
     if(encodings.length == 0) {
       // This most likely is a race condition. Log an error and prevent catastrophic failure
       console.error("Attempted to limit bandwidth of the track that doesn't have any encodings")
@@ -609,7 +614,7 @@ export class MembraneWebRTC {
       (acc, value) => acc + (firstScaleDownBy / (value.scaleResolutionDownBy || 1)) ** 2,
       0
     );
-    const x = bitrate / bitrate_parts;
+    const x = bandwidth / bitrate_parts;
 
     encodings.forEach(
       (value) =>
@@ -689,13 +694,13 @@ export class MembraneWebRTC {
   /**
    * Updates maximum bandwidth for the track identified by trackId.
    * This value directly translates to quality of the stream and, in case of video, to the amount of RTP packets being sent.
-   * In case trackId points at the simulcast track and bandwidth limit is not specified per-layer (using SimulcastBandwidthLimit), bandwidth is split between all of the variant streams proportionally to their resolution.
+   * In case trackId points at the simulcast track bandwidth is split between all of the variant streams proportionally to their resolution.
    *
    * @param {string} trackId
-   * @param {TrackBandwidthLimit} bandwidth in kbps
+   * @param {BandwidthLimit} bandwidth in kbps
    * @returns {Promise<boolean>} success
    */
-  public setTrackBandwidth(trackId: string, bandwidth: TrackBandwidthLimit): Promise<boolean> {
+  public setTrackBandwidth(trackId: string, bandwidth: BandwidthLimit): Promise<boolean> {
     const trackContext = this.localTrackIdToTrack.get(trackId);
     
     if(!trackContext) {
@@ -707,12 +712,8 @@ export class MembraneWebRTC {
 
     if (parameters.encodings.length === 0) {
       parameters.encodings = [{}];
-    }
-    if (bandwidth === 0) {
-      // bandwidth isn't limited, remove any constraints
-      parameters.encodings.forEach((value) => delete value.maxBitrate);
     } else {
-      this.applyBitrateLimitation(parameters.encodings, bandwidth);
+      this.applyBandwidthLimitation(parameters.encodings, bandwidth);
     }
 
     return sender
@@ -722,14 +723,14 @@ export class MembraneWebRTC {
   }
   
   /**
-   * Updates maximum bandwidth for the given simulcast layer of the given track.
+   * Updates maximum bandwidth for the given simulcast encoding of the given track.
    * 
    * @param {string} trackId - id of the track
-   * @param {string} layer - rid of the layer
-   * @param {BandwidthLimit} bandwidth - desired max bitrate of the layer (in kbps)
+   * @param {string} rid - rid of the encoding
+   * @param {BandwidthLimit} bandwidth - desired max bandwidth used by the encoding (in kbps)
    * @returns 
    */
-  public setLayerBandwidth(trackId: string, layer: string, bandwidth: BandwidthLimit): Promise<boolean> {
+  public setEncodingBandwidth(trackId: string, rid: string, bandwidth: BandwidthLimit): Promise<boolean> {
     const trackContext = this.localTrackIdToTrack.get(trackId)!;
 
     if(!trackContext) {
@@ -738,10 +739,10 @@ export class MembraneWebRTC {
 
     const sender = this.findSender(trackContext.track!!.id);
     const parameters = sender.getParameters();
-    const encoding = parameters.encodings.find(encoding => encoding.rid === layer)
+    const encoding = parameters.encodings.find(encoding => encoding.rid === rid)
 
     if(!encoding) {
-      return Promise.reject(`Layer '${layer}' doesn't exist`)
+      return Promise.reject(`Encoding with rid '${rid}' doesn't exist`)
     } else if(bandwidth === 0) {
       delete encoding.maxBitrate
     } else {


### PR DESCRIPTION
This PR introduces the ability to limit the bandwidth of simulcast tracks. It is achieved by the following set of changes:
- addition of `setLayerBandwidth` function
- introduction of new data type - `SimulcastBandwidthLimit` which is a (layer => limit) mapping
- both `setTrackBandwidth` and `addTrack` handle limiting bandwidth of each layer using `SimulcastBandwidthLimit`
- `addTrack` when provided an overall bandwidth limitation for simulcast track splits available bandwith between layer according to their `scaleResolutionDownBy` factors