### PR TITLE
[RTC-26] Fix removing and adding the same track again

### DIFF
--- a/src/membraneWebRTC.ts
+++ b/src/membraneWebRTC.ts
@@ -786,6 +786,8 @@ export class MembraneWebRTC {
     this.connection!.removeTrack(sender);
     let mediaEvent = generateCustomEvent({ type: "renegotiateTracks" });
     this.sendMediaEvent(mediaEvent);
+    this.localTrackIdToTrack.delete(trackId);
+    this.localPeer.trackIdToMetadata.delete(trackId);
   }
 
   /**
@@ -956,11 +958,8 @@ export class MembraneWebRTC {
     this.connection.getTransceivers().forEach((transceiver) => {
       const localTrackId = transceiver.sender.track?.id;
       const mid = transceiver.mid;
-      const trackIds = this.localPeer.trackIdToMetadata.keys();
-      const tracks = Array.from(trackIds).map((track) => this.localTrackIdToTrack.get(track));
-
       if (localTrackId && mid) {
-        const trackContext = tracks.find(
+        const trackContext = Array.from(this.localTrackIdToTrack.values()).find(
           (trackContext) => trackContext!.track!!.id === localTrackId
         )!;
         localTrackMidToTrackId[mid] = trackContext.trackId;


### PR DESCRIPTION
The problem was that we were not cleaning up our internal `localTrackIdToTrack` and as a result we had two different track contexts inside it but with the same `MediaStreamTrack`. Hence, the function `getMidToTrackId`  was mapping new transceiver's mid to the first track context while it should to the second one.

At the end we were sending SDP offer Media Event with `midToTrackId` map containing `mid` mapped to the old, removed track. Then the server, was generating SDP answer with only one m-line.