### PR TITLE
[RTC-43] Allow enabling VAD on an audio track

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@membraneframework/membrane-webrtc-js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@membraneframework/membrane-webrtc-js",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "@types/uuid": "^8.3.1",
     "eslint": "^7.21.0",
     "prettier": "^2.2.1",
-    "typedoc": "^0.21.2",
     "rimraf": "^3.0.2",
+    "typedoc": "^0.21.2",
     "typescript": "^4.2.2"
   },
   "dependencies": {

--- a/src/mediaEvent.ts
+++ b/src/mediaEvent.ts
@@ -6,11 +6,15 @@ export interface MediaEvent {
   data?: any;
 }
 
-export function serializeMediaEvent(mediaEvent: MediaEvent): SerializedMediaEvent {
+export function serializeMediaEvent(
+  mediaEvent: MediaEvent
+): SerializedMediaEvent {
   return JSON.stringify(mediaEvent);
 }
 
-export function deserializeMediaEvent(serializedMediaEvent: SerializedMediaEvent): MediaEvent {
+export function deserializeMediaEvent(
+  serializedMediaEvent: SerializedMediaEvent
+): MediaEvent {
   return JSON.parse(serializedMediaEvent) as MediaEvent;
 }
 

--- a/src/membraneWebRTC.ts
+++ b/src/membraneWebRTC.ts
@@ -578,27 +578,25 @@ export class MembraneWebRTC {
     return trackId;
   }
 
-  private describeLocalTracks(): Map<string, TrackDescription> {
-    let result = new Map() as Map<string, TrackDescription>;
+  private describeLocalTracks(): { [key: string]: TrackDescription } {
+    let result = {} as { [key: string]: TrackDescription };
     const mid_to_track_id = this.getMidToTrackId()!;
 
     for (var mid in mid_to_track_id) {
       const track_id = mid_to_track_id[mid];
       const track = this.localTrackIdToTrack.get(track_id);
 
-      const description = <TrackDescription>{
+      result[mid] = <TrackDescription>{
         track_id,
         mid,
         metadata: track!.metadata,
         active_speaker_detection: track!.active_speaker_detection!,
       };
-
-      result.set(mid, description);
     }
 
-    console.log(result);
+    console.log(JSON.stringify(result));
 
-    return new Map();
+    return result;
   }
 
   private addTrackToConnection = (trackContext: TrackContext) => {

--- a/src/membraneWebRTC.ts
+++ b/src/membraneWebRTC.ts
@@ -526,7 +526,7 @@ export class MembraneWebRTC {
   public addTrack(
     track: MediaStreamTrack,
     stream: MediaStream,
-    options: AddTrackOptions
+    options: AddTrackOptions = {}
   ): string {
     const simulcastConfig = options.simulcast || {
       enabled: false,
@@ -534,7 +534,7 @@ export class MembraneWebRTC {
     };
     const maxBandwidth = options.bandwidth_limit || 0;
     const active_speaker_detection = options.active_speaker_detection || false;
-    const trackMetadata = options.metadata || [];
+    const trackMetadata = options.metadata || {};
 
     if (this.getPeerId() === "")
       throw "Cannot add tracks before being accepted by the server";

--- a/src/membraneWebRTC.ts
+++ b/src/membraneWebRTC.ts
@@ -55,7 +55,7 @@ interface TrackDescription {
   track_id: string;
   mid: string;
   metadata: any;
-  properties: string[];
+  active_speaker_detection: boolean;
 }
 
 /**
@@ -69,7 +69,7 @@ export interface AddTrackOptions {
   simulcast?: SimulcastConfig;
   metadata?: any;
   bandwidth_limit?: BandwidthLimit;
-  properties?: TrackProperty[];
+  active_speaker_detection?: boolean;
 }
 
 /**
@@ -122,7 +122,7 @@ export interface TrackContext {
 
   maxBandwidth?: TrackBandwidthLimit;
 
-  properties?: TrackProperty[];
+  active_speaker_detection?: boolean;
 }
 
 /**
@@ -538,7 +538,7 @@ export class MembraneWebRTC {
       active_encodings: [],
     };
     const maxBandwidth = options.bandwidth_limit || 0;
-    const properties = options.properties || [];
+    const active_speaker_detection = options.active_speaker_detection || false;
     const trackMetadata = options.metadata || [];
 
     if (this.getPeerId() === "")
@@ -555,7 +555,7 @@ export class MembraneWebRTC {
       metadata: trackMetadata,
       simulcastConfig,
       maxBandwidth,
-      properties,
+      active_speaker_detection,
     };
     this.localTrackIdToTrack.set(trackId, trackContext);
 
@@ -586,15 +586,11 @@ export class MembraneWebRTC {
       const track_id = mid_to_track_id[mid];
       const track = this.localTrackIdToTrack.get(track_id);
 
-      const properties = (track!.properties || []).map(
-        (property) => TrackProperty[property]
-      );
-
       const description = <TrackDescription>{
         track_id,
         mid,
         metadata: track!.metadata,
-        properties,
+        active_speaker_detection: track!.active_speaker_detection!,
       };
 
       result.set(mid, description);

--- a/src/membraneWebRTC.ts
+++ b/src/membraneWebRTC.ts
@@ -60,10 +60,36 @@ export interface MembraneWebRTCConfig {
   callbacks: Callbacks;
 }
 
+/**
+ * Interface describing options that can be passed to `{@link addTrack}`
+ */
 export interface AddTrackOptions {
+  /**
+   * Simulcast configuration. By default simulcast is disabled.
+   * For more information refer to {@link SimulcastConfig}.
+   */
   simulcast?: SimulcastConfig;
+  /**
+   * Any information about this track that other peers will
+   * receive in {@link onPeerJoined}. E.g. this can source of the track - wheather it's
+   * screensharing, webcam or some other media device.
+   */
+
   metadata?: any;
+
+  /**
+   * Bandwidth this track can use.
+   * Defaults to 0 which is unlimited.
+   * This option has no effect for simulcast and audio tracks.
+   * For simulcast tracks use `{@link setTrackBandwidth}.
+   */
   bandwidth_limit?: BandwidthLimit;
+
+  /**
+   * Flag controlling Voice Acitivity Detection feature.
+   *
+   * Can only be enabled for one audio track at a time.
+   */
   vad?: boolean;
 }
 
@@ -483,15 +509,7 @@ export class MembraneWebRTC {
    * Adds track that will be sent to the RTC Engine.
    * @param track - Audio or video track e.g. from your microphone or camera.
    * @param stream  - Stream that this track belongs to.
-   * @param trackMetadata - Any information about this track that other peers will
-   * receive in {@link onPeerJoined}. E.g. this can source of the track - wheather it's
-   * screensharing, webcam or some other media device.
-   * @param simulcastConfig - Simulcast configuration. By default simulcast is disabled.
-   * For more information refer to {@link SimulcastConfig}.
-   * @param maxBandwidth - maximal bandwidth this track can use.
-   * Defaults to 0 which is unlimited.
-   * This option has no effect for simulcast and audio tracks.
-   * For simulcast tracks use `{@link setTrackBandwidth}.
+   * @param options - AddTrackOptions
    * @returns {string} Returns id of added track
    * @example
    * ```ts

--- a/src/membraneWebRTC.ts
+++ b/src/membraneWebRTC.ts
@@ -46,11 +46,6 @@ export type SimulcastBandwidthLimit = Map<TrackEncoding, BandwidthLimit>;
  */
 export type TrackBandwidthLimit = BandwidthLimit | SimulcastBandwidthLimit;
 
-export enum TrackProperty {
-  SpeakerDetection,
-  Screenshare,
-}
-
 interface TrackDescription {
   track_id: string;
   mid: string;

--- a/src/membraneWebRTC.ts
+++ b/src/membraneWebRTC.ts
@@ -28,7 +28,6 @@ export interface Peer {
   trackIdToMetadata: Map<string, any>;
 }
 
-
 /**
  * Type describing maximal bandwidth that can be used, in kbps. 0 is interpreted as unlimited bandwidth.
  */
@@ -37,7 +36,7 @@ export type BandwidthLimit = number;
 /**
  * Type describing bandwidth limit for simulcast track.
  * It is a mapping (encoding => BandwidthLimit).
- * If encoding isn't present in this mapping, it will be assumed that this particular encoding shouldn't have any bandwidth limit 
+ * If encoding isn't present in this mapping, it will be assumed that this particular encoding shouldn't have any bandwidth limit
  */
 export type SimulcastBandwidthLimit = Map<TrackEncoding, BandwidthLimit>;
 
@@ -47,11 +46,30 @@ export type SimulcastBandwidthLimit = Map<TrackEncoding, BandwidthLimit>;
  */
 export type TrackBandwidthLimit = BandwidthLimit | SimulcastBandwidthLimit;
 
+export enum TrackProperty {
+  SpeakerDetection,
+  Screenshare,
+}
+
+interface TrackDescription {
+  track_id: string;
+  mid: string;
+  metadata: any;
+  properties: TrackProperty[];
+}
+
 /**
  * Config passed to {@link MembraneWebRTC}.
  */
 export interface MembraneWebRTCConfig {
   callbacks: Callbacks;
+}
+
+export interface AddTrackOptions {
+  simulcast?: SimulcastConfig;
+  metadata?: any;
+  bandwidth_limit?: BandwidthLimit;
+  properties?: TrackProperty[];
 }
 
 /**
@@ -103,6 +121,8 @@ export interface TrackContext {
   metadata: any;
 
   maxBandwidth?: TrackBandwidthLimit;
+
+  properties?: TrackProperty[];
 }
 
 /**
@@ -185,7 +205,10 @@ export interface Callbacks {
    * @param enabledTracks - list of tracks which will be sent to client from SFU
    * @param disabledTracks - list of tracks which will not be sent to client from SFU
    */
-  onTracksPriorityChanged?: (enabledTracks: TrackContext[], disabledTracks: TrackContext[]) => void;
+  onTracksPriorityChanged?: (
+    enabledTracks: TrackContext[],
+    disabledTracks: TrackContext[]
+  ) => void;
 
   /**
    * Called each time track encoding has changed.
@@ -198,7 +221,11 @@ export interface Callbacks {
    * @param {string} trackId - id of track that changed encoding
    * @param {TrackEncoding} encoding - new encoding
    */
-  onTrackEncodingChanged?: (peerId: string, trackId: string, encoding: TrackEncoding) => void;
+  onTrackEncodingChanged?: (
+    peerId: string,
+    trackId: string,
+    encoding: TrackEncoding
+  ) => void;
 
   /**
    * Called every time a local peer is removed by the server.
@@ -217,7 +244,11 @@ export class MembraneWebRTC {
   private trackIdToTrack: Map<string, TrackContext> = new Map();
   private connection?: RTCPeerConnection;
   private idToPeer: Map<String, Peer> = new Map();
-  private localPeer: Peer = { id: "", metadata: {}, trackIdToMetadata: new Map() };
+  private localPeer: Peer = {
+    id: "",
+    metadata: {},
+    trackIdToMetadata: new Map(),
+  };
   private localTrackIdToTrack: Map<string, TrackContext> = new Map();
   private midToTrackId: Map<string, string> = new Map();
   private disabledTrackEncodings: Map<string, TrackEncoding[]> = new Map();
@@ -295,7 +326,8 @@ export class MembraneWebRTC {
         break;
 
       default:
-        if (this.localPeer.id != null) this.handleMediaEvent(deserializedMediaEvent);
+        if (this.localPeer.id != null)
+          this.handleMediaEvent(deserializedMediaEvent);
     }
   };
 
@@ -317,26 +349,33 @@ export class MembraneWebRTC {
       case "tracksAdded":
         data = deserializedMediaEvent.data;
         if (this.getPeerId() === data.peerId) return;
-        data.trackIdToMetadata = new Map<string, any>(Object.entries(data.trackIdToMetadata));
+        data.trackIdToMetadata = new Map<string, any>(
+          Object.entries(data.trackIdToMetadata)
+        );
         peer = this.idToPeer.get(data.peerId)!;
         const oldTrackIdToMetadata = peer.trackIdToMetadata;
-        peer.trackIdToMetadata = new Map([...peer.trackIdToMetadata, ...data.trackIdToMetadata]);
+        peer.trackIdToMetadata = new Map([
+          ...peer.trackIdToMetadata,
+          ...data.trackIdToMetadata,
+        ]);
         this.idToPeer.set(peer.id, peer);
-        Array.from(peer.trackIdToMetadata.entries()).forEach(([trackId, metadata]) => {
-          if (!oldTrackIdToMetadata.has(trackId)) {
-            const ctx = {
-              stream: null,
-              track: null,
-              trackId,
-              simulcastConfig: { enabled: false, active_encodings: [] },
-              metadata,
-              peer,
-              maxBandwidth: 0,
-            };
-            this.trackIdToTrack.set(trackId, ctx);
-            this.callbacks.onTrackAdded?.(ctx);
+        Array.from(peer.trackIdToMetadata.entries()).forEach(
+          ([trackId, metadata]) => {
+            if (!oldTrackIdToMetadata.has(trackId)) {
+              const ctx = {
+                stream: null,
+                track: null,
+                trackId,
+                simulcastConfig: { enabled: false, active_encodings: [] },
+                metadata,
+                peer,
+                maxBandwidth: 0,
+              };
+              this.trackIdToTrack.set(trackId, ctx);
+              this.callbacks.onTrackAdded?.(ctx);
+            }
           }
-        });
+        );
         break;
       case "tracksRemoved":
         data = deserializedMediaEvent.data;
@@ -351,7 +390,9 @@ export class MembraneWebRTC {
         break;
 
       case "sdpAnswer":
-        this.midToTrackId = new Map(Object.entries(deserializedMediaEvent.data.midToTrackId));
+        this.midToTrackId = new Map(
+          Object.entries(deserializedMediaEvent.data.midToTrackId)
+        );
         this.onAnswer(deserializedMediaEvent.data);
         break;
 
@@ -386,7 +427,9 @@ export class MembraneWebRTC {
 
       case "peerRemoved":
         if (this.getPeerId() !== deserializedMediaEvent.data.peerId) {
-          console.error("Received onRemoved media event, but it does not refer to the local peer");
+          console.error(
+            "Received onRemoved media event, but it does not refer to the local peer"
+          );
           return;
         }
 
@@ -396,7 +439,8 @@ export class MembraneWebRTC {
       case "trackUpdated":
         if (this.getPeerId() === deserializedMediaEvent.data.peerId) return;
         peer = this.idToPeer.get(deserializedMediaEvent.data.peerId)!;
-        if (peer == null) throw `Peer with id: ${deserializedMediaEvent.data.peerId} doesn't exist`;
+        if (peer == null)
+          throw `Peer with id: ${deserializedMediaEvent.data.peerId} doesn't exist`;
         const trackId = deserializedMediaEvent.data.trackId;
         const trackMetadata = deserializedMediaEvent.data.metadata;
         peer.trackIdToMetadata.set(trackId, trackMetadata);
@@ -406,9 +450,9 @@ export class MembraneWebRTC {
         break;
 
       case "tracksPriority":
-        const enabledTracks = (deserializedMediaEvent.data.tracks as string[]).map(
-          (trackId) => this.trackIdToTrack.get(trackId)!!
-        );
+        const enabledTracks = (
+          deserializedMediaEvent.data.tracks as string[]
+        ).map((trackId) => this.trackIdToTrack.get(trackId)!!);
         const disabledTracks = Array.from(this.trackIdToTrack.values()).filter(
           (track) => !enabledTracks.includes(track)
         );
@@ -432,7 +476,10 @@ export class MembraneWebRTC {
         break;
 
       default:
-        console.warn("Received unknown media event: ", deserializedMediaEvent.type);
+        console.warn(
+          "Received unknown media event: ",
+          deserializedMediaEvent.type
+        );
         break;
     }
   };
@@ -486,9 +533,11 @@ export class MembraneWebRTC {
     stream: MediaStream,
     trackMetadata: any = new Map(),
     simulcastConfig: SimulcastConfig = { enabled: false, active_encodings: [] },
-    maxBandwidth: TrackBandwidthLimit = 0 // unlimited bandwidth
+    maxBandwidth: TrackBandwidthLimit = 0, // unlimited bandwidth
+    properties: TrackProperty[] = []
   ): string {
-    if (this.getPeerId() === "") throw "Cannot add tracks before being accepted by the server";
+    if (this.getPeerId() === "")
+      throw "Cannot add tracks before being accepted by the server";
     const trackId = this.getTrackId(uuidv4());
     this.localTracksWithStreams.push({ track, stream });
 
@@ -501,6 +550,7 @@ export class MembraneWebRTC {
       metadata: trackMetadata,
       simulcastConfig,
       maxBandwidth,
+      properties,
     };
     this.localTrackIdToTrack.set(trackId, trackContext);
 
@@ -512,7 +562,9 @@ export class MembraneWebRTC {
         .forEach(
           (transceiver) =>
             (transceiver.direction =
-              transceiver.direction === "sendrecv" ? "sendonly" : transceiver.direction)
+              transceiver.direction === "sendrecv"
+                ? "sendonly"
+                : transceiver.direction)
         );
     }
 
@@ -521,13 +573,36 @@ export class MembraneWebRTC {
     return trackId;
   }
 
+  private describeLocalTracks(): Map<string, TrackDescription> {
+    let result = new Map() as Map<string, TrackDescription>;
+    const mid_to_track_id = this.getMidToTrackId()!;
+
+    for (var mid in mid_to_track_id) {
+      const track_id = mid_to_track_id[mid];
+      const track = this.localTrackIdToTrack.get(track_id);
+
+      const description = <TrackDescription>{
+        track_id,
+        mid,
+        metadata: track!.metadata,
+        properties: track!.properties,
+      };
+
+      result.set(mid, description);
+    }
+
+    return new Map();
+  }
+
   private addTrackToConnection = (trackContext: TrackContext) => {
     let transceiverConfig = this.createTransceiverConfig(trackContext);
     const track = trackContext.track!!;
     this.connection!.addTransceiver(track, transceiverConfig);
   };
 
-  private createTransceiverConfig(trackContext: TrackContext): RTCRtpTransceiverInit {
+  private createTransceiverConfig(
+    trackContext: TrackContext
+  ): RTCRtpTransceiverInit {
     let transceiverConfig: RTCRtpTransceiverInit;
 
     if (trackContext.track!!.kind === "audio") {
@@ -539,11 +614,15 @@ export class MembraneWebRTC {
     return transceiverConfig;
   }
 
-  private createAudioTransceiverConfig(_trackContext: TrackContext): RTCRtpTransceiverInit {
+  private createAudioTransceiverConfig(
+    _trackContext: TrackContext
+  ): RTCRtpTransceiverInit {
     return { direction: "sendonly" };
   }
 
-  private createVideoTransceiverConfig(trackContext: TrackContext): RTCRtpTransceiverInit {
+  private createVideoTransceiverConfig(
+    trackContext: TrackContext
+  ): RTCRtpTransceiverInit {
     let transceiverConfig: RTCRtpTransceiverInit;
     if (trackContext.simulcastConfig.enabled) {
       transceiverConfig = simulcastTransceiverConfig;
@@ -556,7 +635,10 @@ export class MembraneWebRTC {
           disabledTrackEncodings.push(encoding.rid! as TrackEncoding);
         }
       });
-      this.disabledTrackEncodings.set(trackContext.trackId, disabledTrackEncodings);
+      this.disabledTrackEncodings.set(
+        trackContext.trackId,
+        disabledTrackEncodings
+      );
     } else {
       transceiverConfig = {
         direction: "sendonly",
@@ -567,39 +649,53 @@ export class MembraneWebRTC {
         ],
       };
     }
-    
-    if(trackContext.maxBandwidth && transceiverConfig.sendEncodings)
-      this.applyBandwidthLimitation(transceiverConfig.sendEncodings, trackContext.maxBandwidth);
+
+    if (trackContext.maxBandwidth && transceiverConfig.sendEncodings)
+      this.applyBandwidthLimitation(
+        transceiverConfig.sendEncodings,
+        trackContext.maxBandwidth
+      );
 
     return transceiverConfig;
   }
-  
-  private applyBandwidthLimitation(encodings: RTCRtpEncodingParameters[], max_bandwidth: TrackBandwidthLimit) {
-    if(typeof max_bandwidth === "number") {
+
+  private applyBandwidthLimitation(
+    encodings: RTCRtpEncodingParameters[],
+    max_bandwidth: TrackBandwidthLimit
+  ) {
+    if (typeof max_bandwidth === "number") {
       // non-simulcast limitation
-      this.splitBandwidth(encodings, (max_bandwidth as number) * 1024)
+      this.splitBandwidth(encodings, (max_bandwidth as number) * 1024);
     } else {
       // simulcast bandwidth limit
-      encodings.filter(encoding => encoding.rid).forEach(encoding => {
-        const limit = (max_bandwidth as SimulcastBandwidthLimit).get(encoding.rid! as TrackEncoding) || 0
+      encodings
+        .filter((encoding) => encoding.rid)
+        .forEach((encoding) => {
+          const limit =
+            (max_bandwidth as SimulcastBandwidthLimit).get(
+              encoding.rid! as TrackEncoding
+            ) || 0;
 
-        if(limit > 0)
-          encoding.maxBitrate = limit * 1024
-        else
-          delete encoding.maxBitrate
-      })
+          if (limit > 0) encoding.maxBitrate = limit * 1024;
+          else delete encoding.maxBitrate;
+        });
     }
   }
-  
-  private splitBandwidth(encodings: RTCRtpEncodingParameters[], bandwidth: number) {
-    if(bandwidth === 0) {
-      encodings.forEach(encoding => delete encoding.maxBitrate) 
+
+  private splitBandwidth(
+    encodings: RTCRtpEncodingParameters[],
+    bandwidth: number
+  ) {
+    if (bandwidth === 0) {
+      encodings.forEach((encoding) => delete encoding.maxBitrate);
       return;
     }
 
-    if(encodings.length == 0) {
+    if (encodings.length == 0) {
       // This most likely is a race condition. Log an error and prevent catastrophic failure
-      console.error("Attempted to limit bandwidth of the track that doesn't have any encodings")
+      console.error(
+        "Attempted to limit bandwidth of the track that doesn't have any encodings"
+      );
       return;
     }
 
@@ -609,14 +705,16 @@ export class MembraneWebRTC {
     // square is dictated by the fact that k0/kn is a scale factor, but we are interested in the total number of pixels in the image
     const firstScaleDownBy = encodings![0].scaleResolutionDownBy || 1;
     const bitrate_parts = encodings.reduce(
-      (acc, value) => acc + (firstScaleDownBy / (value.scaleResolutionDownBy || 1)) ** 2,
+      (acc, value) =>
+        acc + (firstScaleDownBy / (value.scaleResolutionDownBy || 1)) ** 2,
       0
     );
     const x = bandwidth / bitrate_parts;
 
     encodings.forEach(
       (value) =>
-        (value.maxBitrate = x * (firstScaleDownBy / (value.scaleResolutionDownBy || 1)) ** 2)
+        (value.maxBitrate =
+          x * (firstScaleDownBy / (value.scaleResolutionDownBy || 1)) ** 2)
     );
   }
 
@@ -678,7 +776,8 @@ export class MembraneWebRTC {
       return sender
         .replaceTrack(newTrack)
         .then(() => {
-          const trackMetadata = newTrackMetadata || this.localTrackIdToTrack.get(trackId)!.metadata;
+          const trackMetadata =
+            newTrackMetadata || this.localTrackIdToTrack.get(trackId)!.metadata;
           trackContext.track = newTrack;
           this.updateTrackMetadata(trackId, trackMetadata);
           return true;
@@ -698,11 +797,14 @@ export class MembraneWebRTC {
    * @param {BandwidthLimit} bandwidth in kbps
    * @returns {Promise<boolean>} success
    */
-  public setTrackBandwidth(trackId: string, bandwidth: BandwidthLimit): Promise<boolean> {
+  public setTrackBandwidth(
+    trackId: string,
+    bandwidth: BandwidthLimit
+  ): Promise<boolean> {
     const trackContext = this.localTrackIdToTrack.get(trackId);
-    
-    if(!trackContext) {
-      return Promise.reject(`Track '${trackId}' doesn't exist`)
+
+    if (!trackContext) {
+      return Promise.reject(`Track '${trackId}' doesn't exist`);
     }
 
     const sender = this.findSender(trackContext.track!!.id);
@@ -717,32 +819,38 @@ export class MembraneWebRTC {
     return sender
       .setParameters(parameters)
       .then(() => true)
-      .catch(() => false)
+      .catch(() => false);
   }
-  
+
   /**
    * Updates maximum bandwidth for the given simulcast encoding of the given track.
-   * 
+   *
    * @param {string} trackId - id of the track
    * @param {string} rid - rid of the encoding
    * @param {BandwidthLimit} bandwidth - desired max bandwidth used by the encoding (in kbps)
-   * @returns 
+   * @returns
    */
-  public setEncodingBandwidth(trackId: string, rid: string, bandwidth: BandwidthLimit): Promise<boolean> {
+  public setEncodingBandwidth(
+    trackId: string,
+    rid: string,
+    bandwidth: BandwidthLimit
+  ): Promise<boolean> {
     const trackContext = this.localTrackIdToTrack.get(trackId)!;
 
-    if(!trackContext) {
-      return Promise.reject(`Track '${trackId}' doesn't exist`)
+    if (!trackContext) {
+      return Promise.reject(`Track '${trackId}' doesn't exist`);
     }
 
     const sender = this.findSender(trackContext.track!!.id);
     const parameters = sender.getParameters();
-    const encoding = parameters.encodings.find(encoding => encoding.rid === rid)
+    const encoding = parameters.encodings.find(
+      (encoding) => encoding.rid === rid
+    );
 
-    if(!encoding) {
-      return Promise.reject(`Encoding with rid '${rid}' doesn't exist`)
-    } else if(bandwidth === 0) {
-      delete encoding.maxBitrate
+    if (!encoding) {
+      return Promise.reject(`Encoding with rid '${rid}' doesn't exist`);
+    } else if (bandwidth === 0) {
+      delete encoding.maxBitrate;
     } else {
       encoding.maxBitrate = bandwidth * 1024;
     }
@@ -750,7 +858,7 @@ export class MembraneWebRTC {
     return sender
       .setParameters(parameters)
       .then(() => true)
-      .catch((_error) => false)
+      .catch((_error) => false);
   }
 
   /**
@@ -799,7 +907,10 @@ export class MembraneWebRTC {
    * @param {string} trackId - Id of video track to prioritize.
    */
   public prioritizeTrack(trackId: string) {
-    let mediaEvent = generateCustomEvent({ type: "prioritizeTrack", data: { trackId } });
+    let mediaEvent = generateCustomEvent({
+      type: "prioritizeTrack",
+      data: { trackId },
+    });
     this.sendMediaEvent(mediaEvent);
   }
   /**
@@ -811,7 +922,10 @@ export class MembraneWebRTC {
    * @param {string} trackId - Id of video track to unprioritize.
    */
   public unprioritizeTrack(trackId: string) {
-    let mediaEvent = generateCustomEvent({ type: "unprioritizeTrack", data: { trackId } });
+    let mediaEvent = generateCustomEvent({
+      type: "unprioritizeTrack",
+      data: { trackId },
+    });
     this.sendMediaEvent(mediaEvent);
   }
 
@@ -843,11 +957,11 @@ export class MembraneWebRTC {
 
   /**
    * Sets track encoding that server should send to the client library.
-   * 
+   *
    * The encoding will be sent whenever it is available.
    * If choosen encoding is temporarily unavailable, some other encoding
    * will be sent until choosen encoding becomes active again.
-   * 
+   *
    * @param {string} trackId - id of track
    * @param {TrackEncoding} encoding - encoding to receive
    * @example
@@ -861,7 +975,7 @@ export class MembraneWebRTC {
       data: {
         trackId: trackId,
         variant: encoding,
-      }
+      },
     });
 
     this.sendMediaEvent(mediaEvent);
@@ -885,7 +999,9 @@ export class MembraneWebRTC {
       .get(trackId)
       ?.filter((en) => en !== encoding)!;
     this.disabledTrackEncodings.set(trackId, newDisabledTrackEncodings);
-    let sender = this.connection?.getSenders().filter((sender) => sender.track === track)[0];
+    let sender = this.connection
+      ?.getSenders()
+      .filter((sender) => sender.track === track)[0];
     let params = sender?.getParameters();
     params!.encodings.filter((en) => en.rid == encoding)[0].active = true;
     sender?.setParameters(params!);
@@ -904,7 +1020,9 @@ export class MembraneWebRTC {
   public disableTrackEncoding(trackId: string, encoding: TrackEncoding) {
     let track = this.localTrackIdToTrack.get(trackId)?.track;
     this.disabledTrackEncodings.get(trackId)!.push(encoding);
-    let sender = this.connection?.getSenders().filter((sender) => sender.track === track)[0];
+    let sender = this.connection
+      ?.getSenders()
+      .filter((sender) => sender.track === track)[0];
     let params = sender?.getParameters();
     params!.encodings.filter((en) => en.rid == encoding)[0].active = false;
     sender?.setParameters(params!);
@@ -1007,11 +1125,13 @@ export class MembraneWebRTC {
     this.connection!.ontrack = this.onTrack();
     try {
       await this.connection!.setRemoteDescription(answer);
-      this.disabledTrackEncodings.forEach((encodings: TrackEncoding[], trackId: string) => {
-        encodings.forEach((encoding: TrackEncoding) =>
-          this.disableTrackEncoding(trackId, encoding)
-        );
-      });
+      this.disabledTrackEncodings.forEach(
+        (encodings: TrackEncoding[], trackId: string) => {
+          encodings.forEach((encoding: TrackEncoding) =>
+            this.disableTrackEncoding(trackId, encoding)
+          );
+        }
+      );
     } catch (err) {
       console.log(err);
     }
@@ -1037,7 +1157,8 @@ export class MembraneWebRTC {
     toAdd = toAdd.concat(audio);
     toAdd = toAdd.concat(video);
 
-    for (let kind of toAdd) this.connection?.addTransceiver(kind, { direction: "recvonly" });
+    for (let kind of toAdd)
+      this.connection?.addTransceiver(kind, { direction: "recvonly" });
   };
 
   private async createAndSendOffer() {
@@ -1050,8 +1171,7 @@ export class MembraneWebRTC {
         type: "sdpOffer",
         data: {
           sdpOffer: offer,
-          trackIdToTrackMetadata: this.getTrackIdToMetadata(),
-          midToTrackId: this.getMidToTrackId(),
+          tracks_desciption: this.describeLocalTracks(),
         },
       });
       this.sendMediaEvent(mediaEvent);
@@ -1062,14 +1182,18 @@ export class MembraneWebRTC {
 
   private getTrackIdToMetadata = () => {
     const trackIdToMetadata = {} as any;
-    Array.from(this.localPeer.trackIdToMetadata.entries()).forEach(([trackId, metadata]) => {
-      trackIdToMetadata[trackId] = metadata;
-    });
+    Array.from(this.localPeer.trackIdToMetadata.entries()).forEach(
+      ([trackId, metadata]) => {
+        trackIdToMetadata[trackId] = metadata;
+      }
+    );
     return trackIdToMetadata;
   };
 
   private checkIfTrackBelongToPeer = (trackId: string, peer: Peer) =>
-    Array.from(peer.trackIdToMetadata.keys()).some((track) => trackId.startsWith(track));
+    Array.from(peer.trackIdToMetadata.keys()).some((track) =>
+      trackId.startsWith(track)
+    );
 
   private onOfferData = async (offerData: Map<string, number>) => {
     if (!this.connection) {
@@ -1096,7 +1220,9 @@ export class MembraneWebRTC {
     try {
       const iceCandidate = new RTCIceCandidate(candidate);
       if (!this.connection) {
-        throw new Error("Received new remote candidate but RTCConnection is undefined");
+        throw new Error(
+          "Received new remote candidate but RTCConnection is undefined"
+        );
       }
       this.connection.addIceCandidate(iceCandidate);
     } catch (error) {
@@ -1196,7 +1322,9 @@ export class MembraneWebRTC {
   private eraseTrack = (trackId: string, peerId: string) => {
     this.trackIdToTrack.delete(trackId);
     const midToTrackId = Array.from(this.midToTrackId.entries());
-    const [mid, _trackId] = midToTrackId.find(([mid, mapTrackId]) => mapTrackId === trackId)!;
+    const [mid, _trackId] = midToTrackId.find(
+      ([mid, mapTrackId]) => mapTrackId === trackId
+    )!;
     this.midToTrackId.delete(mid);
     this.idToPeer.get(peerId)!.trackIdToMetadata.delete(trackId);
     this.disabledTrackEncodings.delete(trackId);


### PR DESCRIPTION
As part of RTC-43, extending the `sdpOffer` media event with a voice activity detection flag was necessary.
At the same time, `sdpOffer` media event was refactored to get rid of three mid => something maps and replace them with one map.

At the same time, `addTrack` method was refactored to take an options object instead of 4 optional parameters.

The existing code wasn't adequately formatted before I applied the prettier :roll_eyes:. Sorry. The diff is readable though.